### PR TITLE
Fix for PHP 8.1

### DIFF
--- a/index.php
+++ b/index.php
@@ -153,7 +153,7 @@ try {
         if( ! empty($nodes)) {
           foreach($nodes as $node) {
             echo '<tr id="' . $node->name . '">';
-            echo '<td width="175" class="country"><span data-toggle="tooltip" title="' . $node->operator . '">' . $node->country . ' ' . $node->name{3} . '</span></td>';
+            echo '<td width="175" class="country"><span data-toggle="tooltip" title="' . $node->operator . '">' . $node->country . ' ' . $node->name[3] . '</span></td>';
             echo '<td class="result"></td>';
             echo '<td width="50" class="ttl"></td>';
             echo '</tr>';


### PR DESCRIPTION
Array and string offset access syntax with curly braces is no longer supported